### PR TITLE
Fixing gnome 44 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ GNOME Shell extension to show a button on the panel or quick settings menu which
 
 ## Installation
 
-- This extension supports GNOME Shell version 43
+- This extension supports GNOME Shell version 44
 
 **From GNOME Extensions Website**
 

--- a/toggle-workspace-span@arngo.github.com/extension.js
+++ b/toggle-workspace-span@arngo.github.com/extension.js
@@ -63,7 +63,7 @@ const FeatureToggle = GObject.registerClass(
 class FeatureToggle extends QuickSettings.QuickToggle {
     _init() {
         super._init({
-            label: 'Workspaces',
+            title: 'Workspaces',
             gicon: Gio.icon_new_for_string(Me.path + '/icons/workspace-span-on-symbolic.svg'),
             toggleMode: true,
         });

--- a/toggle-workspace-span@arngo.github.com/extension.js
+++ b/toggle-workspace-span@arngo.github.com/extension.js
@@ -94,6 +94,10 @@ class FeatureIndicator extends QuickSettings.SystemIndicator {
         });
         
         QuickSettingsMenu._addItems(this.quickSettingsItems);
+
+        for (const item of this.quickSettingsItems) {
+            QuickSettingsMenu.menu._grid.set_child_below_sibling(item, QuickSettingsMenu._backgroundApps.quickSettingsItems[0]);
+        }
     }
 });
 

--- a/toggle-workspace-span@arngo.github.com/metadata.json
+++ b/toggle-workspace-span@arngo.github.com/metadata.json
@@ -2,9 +2,9 @@
   "description": "Toggle workspaces spanning displays.", 
   "name": "Toggle workspace span", 
   "shell-version": [
-    "43"
+    "44"
   ], 
   "url": "https://github.com/arngo/gnome-shell-extension-toggle-workspace-span", 
   "uuid": "toggle-workspace-span@arngo.github.com", 
-  "version": 3
+  "version": 4
 }


### PR DESCRIPTION
I have never done this, please tell me if I'm doing something wrong.
this should bring the extension up to date with the gnome 44 changes